### PR TITLE
Fix: Deploy Environment Variables/Secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Build
         run: pnpm build
         env:
-          NODE_ENV: production
+          NODE_ENV: ${{ vars.NODE_ENV }}
+          VITE_CONTACT_FORM_ID: ${{ secrets.VITE_CONTACT_FORM_ID }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Description

Expose `VITE_CONTACT_FORM_ID` as a build-time secret and read `NODE_ENV` from a GitHub environment variable instead of hardcoding it in the workflow.

Vite bakes `import.meta.env.*` into the bundle at build time, so env vars must be explicitly passed to the build step or they compile as `undefined`. The contact form was returning `FORM_NOT_FOUND` in production because `VITE_CONTACT_FORM_ID` was not available during the build.

## Jira Ticket

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🛠️ Refactor / Code improvement
- [ ] 🚀 Performance optimization
- [ ] ✅ Test enhancement

## Checklist

- [x] I have tested my changes and verified expected behavior.
- [x] I have performed a self-review of my code.
- [x] I have ensured this PR adheres to coding standards and best practices.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added necessary tests or ensured existing tests pass.
