### PR TITLE
Feature: Color Mode Switcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-start": "^1.167.59",
     "@unpic/react": "^1.0.2",
     "@vitejs/plugin-react": "^6.0.1",
+    "lucide-react": "^1.14.0",
     "nitro": "3.0.260429-beta",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -15,7 +15,7 @@ import {
   zIndex,
 } from "@/theme/tokens";
 import { colors, easings, radii, shadows } from "@/theme/semanticTokens";
-import { slotRecipes } from "@/recipes";
+import { slotRecipes, recipes } from "@/recipes";
 
 export default defineConfig({
   preflight: true,
@@ -60,6 +60,7 @@ export default defineConfig({
       },
       layerStyles,
       textStyles,
+      recipes,
       slotRecipes,
     },
     keyframes,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.5)
       nitro:
         specifier: 3.0.260429-beta
         version: 3.0.260429-beta(chokidar@4.0.3)(jiti@2.6.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
@@ -2302,6 +2305,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -5723,6 +5731,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.14.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   magic-string@0.30.21:
     dependencies:

--- a/src/components/core/Icon/Icon.tsx
+++ b/src/components/core/Icon/Icon.tsx
@@ -1,0 +1,9 @@
+import { ark } from "@ark-ui/react/factory";
+import type { ComponentProps } from "react";
+import { styled } from "@/styled-system/jsx";
+import { icon } from "@/styled-system/recipes";
+
+export type IconProps = ComponentProps<typeof Icon>;
+export const Icon = styled(ark.svg, icon, {
+  defaultProps: { asChild: true },
+});

--- a/src/components/core/Menu/Menu.tsx
+++ b/src/components/core/Menu/Menu.tsx
@@ -6,40 +6,40 @@ import { menu } from "@/styled-system/recipes";
 
 const { withRootProvider, withContext } = createStyleContext(menu);
 
-export type RootProps = ComponentProps<typeof Root>;
-export const Root = withRootProvider(ReactMenu.Root, {
+export type MenuRootProps = ComponentProps<typeof MenuRoot>;
+export const MenuRoot = withRootProvider(ReactMenu.Root, {
   defaultProps: { unmountOnExit: true, lazyMount: true },
 });
-export const RootProvider = withRootProvider(ReactMenu.Root, {
+export const MenuRootProvider = withRootProvider(ReactMenu.Root, {
   defaultProps: { unmountOnExit: true, lazyMount: true },
 });
-export const Arrow = withContext(ReactMenu.Arrow, "arrow");
-export const ArrowTip = withContext(ReactMenu.ArrowTip, "arrowTip");
-export const CheckboxItem = withContext(ReactMenu.CheckboxItem, "item");
-export const Content = withContext(ReactMenu.Content, "content");
-export const ContextTrigger = withContext(
+export const MenuArrow = withContext(ReactMenu.Arrow, "arrow");
+export const MenuArrowTip = withContext(ReactMenu.ArrowTip, "arrowTip");
+export const MenuCheckboxItem = withContext(ReactMenu.CheckboxItem, "item");
+export const MenuContent = withContext(ReactMenu.Content, "content");
+export const MenuContextTrigger = withContext(
   ReactMenu.ContextTrigger,
   "contextTrigger",
 );
-export const Indicator = withContext(ReactMenu.Indicator, "indicator", {
+export const MenuIndicator = withContext(ReactMenu.Indicator, "indicator", {
   defaultProps: { children: <ChevronDown /> },
 });
-export const Item = withContext(ReactMenu.Item, "item");
-export const ItemGroup = withContext(ReactMenu.ItemGroup, "itemGroup");
-export const ItemGroupLabel = withContext(
+export const MenuItem = withContext(ReactMenu.Item, "item");
+export const MenuItemGroup = withContext(ReactMenu.ItemGroup, "itemGroup");
+export const MenuItemGroupLabel = withContext(
   ReactMenu.ItemGroupLabel,
   "itemGroupLabel",
 );
-export const ItemText = withContext(ReactMenu.ItemText, "itemText");
-export const Positioner = withContext(ReactMenu.Positioner, "positioner");
-export const RadioItem = withContext(ReactMenu.RadioItem, "item");
-export const RadioItemGroup = withContext(
+export const MenuItemText = withContext(ReactMenu.ItemText, "itemText");
+export const MenuPositioner = withContext(ReactMenu.Positioner, "positioner");
+export const MenuRadioItem = withContext(ReactMenu.RadioItem, "item");
+export const MenuRadioItemGroup = withContext(
   ReactMenu.RadioItemGroup,
   "itemGroup",
 );
-export const Separator = withContext(ReactMenu.Separator, "separator");
-export const Trigger = withContext(ReactMenu.Trigger, "trigger");
-export const TriggerItem = withContext(ReactMenu.TriggerItem, "item");
+export const MenuSeparator = withContext(ReactMenu.Separator, "separator");
+export const MenuTrigger = withContext(ReactMenu.Trigger, "trigger");
+export const MenuTriggerItem = withContext(ReactMenu.TriggerItem, "item");
 
 export {
   MenuContext as Context,
@@ -51,38 +51,17 @@ const StyledItemIndicator = withContext(
   "itemIndicator",
 );
 
-export const ItemIndicator = forwardRef<HTMLDivElement, HTMLStyledProps<"div">>(
-  function ItemIndicator(props, ref) {
-    const item = useMenuItemContext();
+export const MenuItemIndicator = forwardRef<
+  HTMLDivElement,
+  HTMLStyledProps<"div">
+>(function MenuItemIndicator(props, ref) {
+  const item = useMenuItemContext();
 
-    return item.checked ? (
-      <StyledItemIndicator ref={ref} {...props}>
-        <Check />
-      </StyledItemIndicator>
-    ) : (
-      <svg aria-hidden="true" focusable="false" />
-    );
-  },
-);
-
-export const Menu = {
-  Root,
-  RootProvider,
-  Arrow,
-  ArrowTip,
-  CheckboxItem,
-  Content,
-  ContextTrigger,
-  Indicator,
-  Item,
-  ItemGroup,
-  ItemGroupLabel,
-  ItemText,
-  Positioner,
-  RadioItem,
-  RadioItemGroup,
-  Separator,
-  Trigger,
-  TriggerItem,
-  ItemIndicator,
-};
+  return item.checked ? (
+    <StyledItemIndicator ref={ref} {...props}>
+      <Check />
+    </StyledItemIndicator>
+  ) : (
+    <svg aria-hidden="true" focusable="false" />
+  );
+});

--- a/src/components/core/Menu/Menu.tsx
+++ b/src/components/core/Menu/Menu.tsx
@@ -1,0 +1,88 @@
+import { Menu as ReactMenu, useMenuItemContext } from "@ark-ui/react/menu";
+import { Check, ChevronDown } from "lucide-react";
+import { type ComponentProps, forwardRef } from "react";
+import { createStyleContext, type HTMLStyledProps } from "@/styled-system/jsx";
+import { menu } from "@/styled-system/recipes";
+
+const { withRootProvider, withContext } = createStyleContext(menu);
+
+export type RootProps = ComponentProps<typeof Root>;
+export const Root = withRootProvider(ReactMenu.Root, {
+  defaultProps: { unmountOnExit: true, lazyMount: true },
+});
+export const RootProvider = withRootProvider(ReactMenu.Root, {
+  defaultProps: { unmountOnExit: true, lazyMount: true },
+});
+export const Arrow = withContext(ReactMenu.Arrow, "arrow");
+export const ArrowTip = withContext(ReactMenu.ArrowTip, "arrowTip");
+export const CheckboxItem = withContext(ReactMenu.CheckboxItem, "item");
+export const Content = withContext(ReactMenu.Content, "content");
+export const ContextTrigger = withContext(
+  ReactMenu.ContextTrigger,
+  "contextTrigger",
+);
+export const Indicator = withContext(ReactMenu.Indicator, "indicator", {
+  defaultProps: { children: <ChevronDown /> },
+});
+export const Item = withContext(ReactMenu.Item, "item");
+export const ItemGroup = withContext(ReactMenu.ItemGroup, "itemGroup");
+export const ItemGroupLabel = withContext(
+  ReactMenu.ItemGroupLabel,
+  "itemGroupLabel",
+);
+export const ItemText = withContext(ReactMenu.ItemText, "itemText");
+export const Positioner = withContext(ReactMenu.Positioner, "positioner");
+export const RadioItem = withContext(ReactMenu.RadioItem, "item");
+export const RadioItemGroup = withContext(
+  ReactMenu.RadioItemGroup,
+  "itemGroup",
+);
+export const Separator = withContext(ReactMenu.Separator, "separator");
+export const Trigger = withContext(ReactMenu.Trigger, "trigger");
+export const TriggerItem = withContext(ReactMenu.TriggerItem, "item");
+
+export {
+  MenuContext as Context,
+  type MenuSelectionDetails as SelectionDetails,
+} from "@ark-ui/react/menu";
+
+const StyledItemIndicator = withContext(
+  ReactMenu.ItemIndicator,
+  "itemIndicator",
+);
+
+export const ItemIndicator = forwardRef<HTMLDivElement, HTMLStyledProps<"div">>(
+  function ItemIndicator(props, ref) {
+    const item = useMenuItemContext();
+
+    return item.checked ? (
+      <StyledItemIndicator ref={ref} {...props}>
+        <Check />
+      </StyledItemIndicator>
+    ) : (
+      <svg aria-hidden="true" focusable="false" />
+    );
+  },
+);
+
+export const Menu = {
+  Root,
+  RootProvider,
+  Arrow,
+  ArrowTip,
+  CheckboxItem,
+  Content,
+  ContextTrigger,
+  Indicator,
+  Item,
+  ItemGroup,
+  ItemGroupLabel,
+  ItemText,
+  Positioner,
+  RadioItem,
+  RadioItemGroup,
+  Separator,
+  Trigger,
+  TriggerItem,
+  ItemIndicator,
+};

--- a/src/components/core/Toast/Toast.tsx
+++ b/src/components/core/Toast/Toast.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import * as ToastPrimitive from "@radix-ui/react-toast";
-import { LuX } from "react-icons/lu";
+import { X } from "lucide-react";
 import { styled } from "@/styled-system/jsx";
 import { toast, toastViewport } from "@/components/core/Toast/Toast.recipe";
 import { createStyleContext } from "@/utils/style-context";
-import { icon } from "@/recipes/icon";
+import { icon } from "@/styled-system/recipes";
 
 const { withProvider, withContext } = createStyleContext(toast);
 
@@ -16,7 +16,7 @@ export const Toast = withProvider(styled(ToastPrimitive.Root), "root", {
 
 export const ToastAction = withContext(styled(ToastPrimitive.Action), "action");
 export const ToastClose = withContext(styled(ToastPrimitive.Close), "close", {
-  children: <LuX className={icon({ size: "lg" })} />,
+  children: <X className={icon({ size: "lg" })} />,
 });
 
 export const ToastTitle = withContext(styled(ToastPrimitive.Title), "title");

--- a/src/components/features/HomePage/ContactUs/ContactForm.tsx
+++ b/src/components/features/HomePage/ContactUs/ContactForm.tsx
@@ -7,7 +7,7 @@ import { TextInput } from "@/components/core/TextInput/TextInput";
 import { TextArea } from "@/components/core/TextArea/TextArea";
 import { Text } from "@/components/core/Text/Text";
 import { Button } from "@/components/core/Button/Button";
-import { PiSpinnerBold } from "react-icons/pi";
+import { LoaderCircle } from "lucide-react";
 import { VStack, styled } from "@/styled-system/jsx";
 import { useToast } from "@/components/core/Toast/Toast.hooks";
 
@@ -56,8 +56,7 @@ export const ContactForm = () => {
       reset(defaultValues);
     } else {
       const formErrs = result.getFormErrors();
-      console.log({ formErrs });
-      for (const { code, message } of formErrs) {
+for (const { code, message } of formErrs) {
         setError(`root.${code}`, { type: code, message });
       }
       const fieldErrs = result.getAllFieldErrors();
@@ -149,7 +148,7 @@ export const ContactForm = () => {
       <Button type="submit" w="full" size="lg" disabled={isSubmitting}>
         {isSubmitting ? (
           <styled.div animation="spin" animationDelay="faster">
-            <PiSpinnerBold size={21} />
+            <LoaderCircle size={21} />
           </styled.div>
         ) : (
           "Send Message"

--- a/src/components/shared/ColorModeSwitcher/ColorModeSwitcher.constants.ts
+++ b/src/components/shared/ColorModeSwitcher/ColorModeSwitcher.constants.ts
@@ -1,0 +1,18 @@
+import { ElementType } from "react";
+import { ColorModePreference, ResolvedColorMode } from "@/utils/colorMode";
+import { Monitor, Sun, Moon } from "lucide-react";
+
+export const OPTIONS: {
+  value: ColorModePreference;
+  label: string;
+  Icon: React.ElementType;
+}[] = [
+  { value: "light", label: "Light", Icon: Sun },
+  { value: "dark", label: "Dark", Icon: Moon },
+  { value: "system", label: "System", Icon: Monitor },
+];
+
+export const resolvedIcon: Record<ResolvedColorMode, ElementType> = {
+  light: Sun,
+  dark: Moon,
+};

--- a/src/components/shared/ColorModeSwitcher/ColorModeSwitcher.hooks.ts
+++ b/src/components/shared/ColorModeSwitcher/ColorModeSwitcher.hooks.ts
@@ -1,0 +1,34 @@
+import { useRef } from "react";
+import { applyColorMode, resolveColorMode } from "@/utils/colorMode";
+import { useColorMode } from "@/hooks/useColorMode";
+import type { ColorModePreference } from "@/utils/colorMode";
+
+export function useColorModeSwitcher() {
+  const { preference, resolved, setPreference } = useColorMode();
+  const committedPreference = useRef<ColorModePreference>(preference);
+
+  const onOpenChange = ({ open }: { open: boolean }) => {
+    if (!open) applyColorMode(resolveColorMode(committedPreference.current));
+  };
+
+  const onHighlightChange = ({
+    highlightedValue,
+  }: {
+    highlightedValue: string | null;
+  }) => {
+    if (highlightedValue) {
+      applyColorMode(resolveColorMode(highlightedValue as ColorModePreference));
+    } else {
+      applyColorMode(resolveColorMode(committedPreference.current));
+    }
+  };
+
+  return {
+    preference,
+    resolved,
+    setPreference,
+    committedPreference,
+    onOpenChange,
+    onHighlightChange,
+  };
+}

--- a/src/components/shared/ColorModeSwitcher/ColorModeSwitcher.tsx
+++ b/src/components/shared/ColorModeSwitcher/ColorModeSwitcher.tsx
@@ -1,16 +1,14 @@
 import {
-  Root as MenuRoot,
-  Trigger as MenuTrigger,
-  Positioner as MenuPositioner,
-  Content as MenuContent,
-  RadioItemGroup as MenuRadioItemGroup,
-  RadioItem as MenuRadioItem,
-  ItemText as MenuItemText,
+  MenuRoot,
+  MenuTrigger,
+  MenuPositioner,
+  MenuContent,
+  MenuRadioItemGroup,
+  MenuRadioItem,
+  MenuItemText,
 } from "@/components/core/Menu/Menu";
-import { useRef } from "react";
 import { useColorModeSwitcher } from "@/components/shared/ColorModeSwitcher/ColorModeSwitcher.hooks";
-import type { ColorModePreference, ResolvedColorMode } from "@/utils/colorMode";
-import { applyColorMode, resolveColorMode } from "@/utils/colorMode";
+import type { ColorModePreference } from "@/utils/colorMode";
 import { css } from "@/styled-system/css";
 import {
   OPTIONS,

--- a/src/components/shared/ColorModeSwitcher/ColorModeSwitcher.tsx
+++ b/src/components/shared/ColorModeSwitcher/ColorModeSwitcher.tsx
@@ -1,0 +1,92 @@
+import {
+  Root as MenuRoot,
+  Trigger as MenuTrigger,
+  Positioner as MenuPositioner,
+  Content as MenuContent,
+  RadioItemGroup as MenuRadioItemGroup,
+  RadioItem as MenuRadioItem,
+  ItemText as MenuItemText,
+} from "@/components/core/Menu/Menu";
+import { useRef } from "react";
+import { useColorModeSwitcher } from "@/components/shared/ColorModeSwitcher/ColorModeSwitcher.hooks";
+import type { ColorModePreference, ResolvedColorMode } from "@/utils/colorMode";
+import { applyColorMode, resolveColorMode } from "@/utils/colorMode";
+import { css } from "@/styled-system/css";
+import {
+  OPTIONS,
+  resolvedIcon,
+} from "@/components/shared/ColorModeSwitcher/ColorModeSwitcher.constants";
+
+export const ColorModeSwitcher = () => {
+  const {
+    preference,
+    resolved,
+    setPreference,
+    committedPreference,
+    onOpenChange,
+    onHighlightChange,
+  } = useColorModeSwitcher();
+  const TriggerIcon = resolvedIcon[resolved];
+
+  return (
+    <MenuRoot onOpenChange={onOpenChange} onHighlightChange={onHighlightChange}>
+      <MenuTrigger
+        className={css({
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          w: "9",
+          h: "9",
+          rounded: "md",
+          color: "fg.muted",
+          cursor: "pointer",
+          border: "none",
+          bg: "transparent",
+          fontSize: "md",
+          transition: "colors",
+          _hover: { bg: "bg.subtle", color: "fg.default" },
+        })}
+        aria-label="Toggle color mode"
+      >
+        <TriggerIcon />
+      </MenuTrigger>
+
+      <MenuPositioner>
+        <MenuContent>
+          <MenuRadioItemGroup
+            value={preference}
+            onValueChange={({ value }) => {
+              committedPreference.current = value as ColorModePreference;
+              setPreference(value as ColorModePreference);
+            }}
+          >
+            {OPTIONS.map(({ value, label, Icon }) => (
+              <MenuRadioItem
+                key={value}
+                value={value}
+                className={css({
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "2",
+                  px: "3",
+                  py: "2",
+                  rounded: "sm",
+                  fontSize: "sm",
+                  cursor: "pointer",
+                  color: "fg.muted",
+                  outline: "none",
+                  _hover: { bg: "bg.subtle", color: "fg.default" },
+                  _highlighted: { bg: "bg.subtle", color: "fg.default" },
+                  "&[data-state=checked]": { color: "accent.default" },
+                })}
+              >
+                <Icon />
+                <MenuItemText fontWeight="bold">{label}</MenuItemText>
+              </MenuRadioItem>
+            ))}
+          </MenuRadioItemGroup>
+        </MenuContent>
+      </MenuPositioner>
+    </MenuRoot>
+  );
+};

--- a/src/components/shared/Header/Header.tsx
+++ b/src/components/shared/Header/Header.tsx
@@ -1,13 +1,14 @@
-// import { MobileDrawerMenu } from "./MobileDrawerMenu";
 import { Logo } from "../core/Logo/Logo";
 import { NavItems } from "../features/Navigation/NavItems";
 import { HeaderWrapper } from "../features/Header/HeaderWrapper";
+import { ColorModeSwitcher } from "@/components/shared/ColorModeSwitcher/ColorModeSwitcher";
 
 export const Header = () => {
   return (
     <HeaderWrapper>
       <Logo />
       <NavItems gap={10} display={{ base: "none", md: "flex" }} />
+      <ColorModeSwitcher />
       {/* <MobileDrawerMenu /> */}
     </HeaderWrapper>
   );

--- a/src/components/shared/MobileDrawerMenu/MobileDrawerMenu.tsx
+++ b/src/components/shared/MobileDrawerMenu/MobileDrawerMenu.tsx
@@ -7,9 +7,10 @@ import {
   DrawerProps,
   DrawerTrigger,
 } from "@/components/core/Drawer/Drawer";
-import { LuX, LuMenu } from "react-icons/lu";
+import { X, Menu as MenuIcon } from "lucide-react";
 import { Logo } from "@/components/core/Logo/Logo";
 import { NavItems } from "@/components/features/Navigation/NavItems";
+import { Icon } from "@/components/core/Icon/Icon";
 
 type MobileDrawerMenuProps = DrawerProps;
 
@@ -23,7 +24,9 @@ export const MobileDrawerMenu = ({ ...restProps }: MobileDrawerMenuProps) => {
       {...restProps}
     >
       <DrawerTrigger asChild cursor="pointer">
-        <LuMenu size={36} />
+        <Icon size="lg">
+          <MenuIcon />
+        </Icon>
       </DrawerTrigger>
       <DrawerContent>
         <DrawerHeader
@@ -34,7 +37,9 @@ export const MobileDrawerMenu = ({ ...restProps }: MobileDrawerMenuProps) => {
         >
           <Logo />
           <DrawerClose mr={-2} cursor="pointer">
-            <LuX size={36} />
+            <Icon size="lg">
+              <X />
+            </Icon>
           </DrawerClose>
         </DrawerHeader>
         <NavItems orientation="vertical" haveIcons={true} size="lg" />

--- a/src/components/shared/RootLayout/RootLayout.tsx
+++ b/src/components/shared/RootLayout/RootLayout.tsx
@@ -1,22 +1,24 @@
-import {
-  Outlet,
-  createRootRoute,
-  HeadContent,
-  Scripts,
-} from "@tanstack/react-router";
+import { Outlet, HeadContent, Scripts } from "@tanstack/react-router";
 import { Main } from "@/components/core/Main/Main";
 import { Footer } from "@/components/shared/Footer/Footer";
 import { Toaster } from "@/components/shared/Toaster/Toaster";
 import { ToastProvider } from "@/components/core/Toast/Toast.context";
+import { COLOR_MODE_INIT_SCRIPT } from "@/utils/colorMode";
+import { ColorModeSwitcher } from "@/components/shared/ColorModeSwitcher/ColorModeSwitcher";
+import { Box } from "@/styled-system/jsx";
 
 export const RootLayout = () => {
   return (
-    <html lang="en" data-color-mode="light">
+    <html lang="en" data-color-mode="light" suppressHydrationWarning>
       <head>
         <HeadContent />
+        <script dangerouslySetInnerHTML={{ __html: COLOR_MODE_INIT_SCRIPT }} />
       </head>
       <body>
         <ToastProvider>
+          <Box position="absolute" top="4" right="4" zIndex="overlay">
+            <ColorModeSwitcher />
+          </Box>
           <Main display="flex" flexDir="column" minHeight="[100dvh]">
             <Outlet />
             <Footer />

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -1,9 +1,9 @@
-import { LuCode, LuBookOpen, LuMail } from "react-icons/lu";
+import { Code, BookOpen, Mail } from "lucide-react";
 
 export const NAV_ITEMS = [
-  { id: 1, label: "About", path: "/about", Icon: LuCode },
-  { id: 2, label: "Blog", path: "/blog", Icon: LuBookOpen },
-  { id: 3, label: "Contact", path: "/contact", Icon: LuMail },
+  { id: 1, label: "About", path: "/about", Icon: Code },
+  { id: 2, label: "Blog", path: "/blog", Icon: BookOpen },
+  { id: 3, label: "Contact", path: "/contact", Icon: Mail },
 ];
 
 // export const NAV_LINKS = [];

--- a/src/hooks/useColorMode.ts
+++ b/src/hooks/useColorMode.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  COLOR_MODE_EVENT,
+  type ColorModePreference,
+  type ResolvedColorMode,
+  applyColorMode,
+  getSystemColorMode,
+  readPreference,
+  resolveColorMode,
+  savePreference,
+} from "@/utils/colorMode";
+
+export function useColorMode() {
+  const [preference, setPreferenceState] =
+    useState<ColorModePreference>("system");
+  const [resolved, setResolved] = useState<ResolvedColorMode>("light");
+
+  useEffect(() => {
+    const pref = readPreference();
+    setPreferenceState(pref);
+    setResolved(resolveColorMode(pref));
+  }, []);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      if (preference === "system") {
+        const sys = getSystemColorMode();
+        setResolved(sys);
+        applyColorMode(sys);
+      }
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [preference]);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const pref = (e as CustomEvent<ColorModePreference>).detail;
+      setPreferenceState(pref);
+      setResolved(resolveColorMode(pref));
+    };
+    window.addEventListener(COLOR_MODE_EVENT, handler);
+    return () => window.removeEventListener(COLOR_MODE_EVENT, handler);
+  }, []);
+
+  const setPreference = useCallback((pref: ColorModePreference) => {
+    const next = resolveColorMode(pref);
+    setPreferenceState(pref);
+    setResolved(next);
+    savePreference(pref);
+    applyColorMode(next);
+    window.dispatchEvent(
+      new CustomEvent<ColorModePreference>(COLOR_MODE_EVENT, { detail: pref }),
+    );
+  }, []);
+
+  return { preference, resolved, setPreference };
+}

--- a/src/recipes/icon.ts
+++ b/src/recipes/icon.ts
@@ -1,64 +1,25 @@
-import { cva } from "@/styled-system/css";
+import { defineRecipe } from "@pandacss/dev";
 
-export const icon = cva({
-  base: {},
-  variants: {
-    size: {
-      xl: {
-        h: "6",
-        w: "6",
-      },
-      lg: {
-        h: "5",
-        w: "5",
-      },
-      md: {
-        h: "4",
-        w: "4",
-      },
-      sm: {
-        h: "3",
-        w: "3",
-      },
-      xs: {
-        h: "2",
-        w: "2",
-      },
-    },
-    left: {
-      none: {},
-      sm: {
-        ml: "2",
-      },
-      auto: {
-        ml: "auto",
-      },
-    },
-    right: {
-      none: {},
-      sm: {
-        mr: "2",
-      },
-      auto: {
-        mr: "auto",
-      },
-    },
-    fillCurrent: {
-      true: {
-        fill: "currentColor",
-      },
-    },
-    dimmed: {
-      true: {
-        opacity: "0.5",
-      },
-    },
+export const icon = defineRecipe({
+  className: "icon",
+  base: {
+    color: "currentcolor",
+    display: "inline-block",
+    flexShrink: "0",
+    verticalAlign: "middle",
+    lineHeight: "1em",
   },
   defaultVariants: {
     size: "md",
-    left: "none",
-    right: "none",
-    fillCurrent: false,
-    dimmed: false,
+  },
+  variants: {
+    size: {
+      "2xs": { boxSize: "3" },
+      xs: { boxSize: "4" },
+      sm: { boxSize: "4.5" },
+      md: { boxSize: "5" },
+      lg: { boxSize: "5.5" },
+      xl: { boxSize: "6" },
+    },
   },
 });

--- a/src/recipes/index.ts
+++ b/src/recipes/index.ts
@@ -1,5 +1,12 @@
 import { card } from "./card";
+import { menu } from "./menu";
+import { icon } from "./icon";
 
 export const slotRecipes = {
   card,
+  menu,
+};
+
+export const recipes = {
+  icon,
 };

--- a/src/recipes/menu.ts
+++ b/src/recipes/menu.ts
@@ -1,0 +1,123 @@
+import { menuAnatomy } from "@ark-ui/react/anatomy";
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const menu = defineSlotRecipe({
+  className: "menu",
+  slots: menuAnatomy.keys(),
+  base: {
+    content: {
+      "--menu-z-index": "zIndex.dropdown",
+
+      layerStyle: "surfaceOverlay",
+      borderRadius: "l3",
+      display: "flex",
+      flexDirection: "column",
+      maxH: "min(var(--available-height), {sizes.96})",
+      minWidth: "max(var(--reference-width), {sizes.40})",
+      outline: "0",
+      overflow: "hidden",
+      overflowY: "auto",
+      position: "relative",
+      zIndex: "calc(var(--menu-z-index) + var(--layer-index, 0))",
+      _open: {
+        animationStyle: "slide-fade-in",
+      },
+      _closed: {
+        animationStyle: "slide-fade-out",
+      },
+    },
+    item: {
+      alignItems: "center",
+      borderRadius: "l2",
+      display: "flex",
+      flex: "0 0 auto",
+      outline: "0",
+      textAlign: "start",
+      textDecoration: "none",
+      userSelect: "none",
+      width: "100%",
+      _highlighted: {
+        bg: "gray.surface.bg.hover",
+      },
+      _focusVisible: {
+        focusVisibleRing: "outside",
+      },
+      _disabled: {
+        layerStyle: "disabled",
+      },
+    },
+    trigger: {
+      _focusVisible: {
+        focusVisibleRing: "outside",
+      },
+    },
+    itemGroupLabel: {
+      alignItems: "flex-start",
+      color: "fg.subtle",
+      display: "flex",
+      flexDirection: "column",
+      fontWeight: "medium",
+      gap: "1px",
+      justifyContent: "center",
+      _after: {
+        content: '""',
+        width: "100%",
+        height: "1px",
+        bg: "border",
+      },
+    },
+    itemIndicator: {
+      justifyContent: "flex-end",
+      display: "flex",
+      flex: "1",
+      _checked: {
+        _icon: {
+          color: "colorPalette.plain.fg",
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
+
+  variants: {
+    size: {
+      xs: {
+        content: { p: "1", gap: "0.5", textStyle: "sm" },
+        item: { px: "1", minH: "8", gap: "2", _icon: { boxSize: "3.5" } },
+        itemGroup: { gap: "0.5" },
+        itemGroupLabel: { px: "1", height: "8" },
+        separator: { mx: "-1", my: "0.5" },
+      },
+      sm: {
+        content: { p: "1", gap: "0.5", textStyle: "sm" },
+        item: { px: "1.5", minH: "9", gap: "2", _icon: { boxSize: "4" } },
+        itemGroup: { gap: "0.5" },
+        itemGroupLabel: { px: "1.5", height: "9" },
+        separator: { mx: "-1.5", my: "0.5" },
+      },
+      md: {
+        content: { p: "1", gap: "0.5", textStyle: "md" },
+        item: { px: "2", minH: "10", gap: "2", _icon: { boxSize: "4" } },
+        itemGroup: { gap: "0.5" },
+        itemGroupLabel: { px: "2", height: "10" },
+        separator: { mx: "-2", my: "0.5" },
+      },
+      lg: {
+        content: { p: "1", gap: "0.5", textStyle: "md" },
+        item: { px: "2.5", minH: "11", gap: "2", _icon: { boxSize: "4.5" } },
+        itemGroup: { gap: "0.5" },
+        itemGroupLabel: { px: "2.5", height: "11" },
+        separator: { mx: "-2.5", my: "0.5" },
+      },
+      xl: {
+        content: { p: "1", gap: "1", textStyle: "lg" },
+        item: { px: "3", minH: "12", gap: "3", _icon: { boxSize: "5" } },
+        itemGroup: { gap: "1" },
+        itemGroupLabel: { px: "3", height: "12" },
+        separator: { mx: "-3", my: "0" },
+      },
+    },
+  },
+});

--- a/src/utils/colorMode.ts
+++ b/src/utils/colorMode.ts
@@ -1,0 +1,38 @@
+export type ColorModePreference = "light" | "dark" | "system";
+export type ResolvedColorMode = "light" | "dark";
+
+export const COLOR_MODE_KEY = "color-mode";
+export const COLOR_MODE_ATTR = "data-color-mode";
+export const COLOR_MODE_EVENT = "color-mode-change";
+
+export function getSystemColorMode(): ResolvedColorMode {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function resolveColorMode(pref: ColorModePreference): ResolvedColorMode {
+  return pref === "system" ? getSystemColorMode() : pref;
+}
+
+export function readPreference(): ColorModePreference {
+  try {
+    const stored = localStorage.getItem(COLOR_MODE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "system")
+      return stored;
+  } catch (_) {}
+  return "system";
+}
+
+export function savePreference(pref: ColorModePreference): void {
+  try {
+    localStorage.setItem(COLOR_MODE_KEY, pref);
+  } catch (_) {}
+}
+
+export function applyColorMode(resolved: ResolvedColorMode): void {
+  document.documentElement.setAttribute(COLOR_MODE_ATTR, resolved);
+}
+
+export const COLOR_MODE_INIT_SCRIPT = `(function(){try{var p=localStorage.getItem('color-mode')||'system';var r=p==='system'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-color-mode',r);}catch(_){}})();`;


### PR DESCRIPTION
## Description

Implements a light/dark/system color mode switcher backed by a three-option menu (Light, Dark, System). The selected preference is persisted to `localStorage` and applied to the `data-color-mode` attribute on `<html>`. An inline init script in `<head>` reads the preference before first paint to prevent flash.

Keyboard and mouse navigation both preview the color mode in real time — arrowing through or hovering over options applies the mode immediately, reverting on Escape or mouse-out without saving. Selecting an option commits it.

Supporting changes:
- Menu and Icon Ark UI core components, backed by new Panda CSS recipes registered in `panda.config.ts`
- Full migration from `react-icons` to `lucide-react` across all components

## Jira Ticket

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔥 Breaking change
- [ ] 📚 Documentation update
- [x] 🛠️ Refactor / Code improvement
- [ ] 🚀 Performance optimization
- [ ] ✅ Test enhancement

## Checklist

- [x] I have tested my changes and verified expected behavior.
- [x] I have performed a self-review of my code.
- [x] I have ensured this PR adheres to coding standards and best practices.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added necessary tests or ensured existing tests pass.
