### PR TITLE
Fix: Mobile Layout

### DIFF
--- a/src/components/features/HomePage/Members/Member.tsx
+++ b/src/components/features/HomePage/Members/Member.tsx
@@ -41,9 +41,6 @@ export const Member = ({
           outlineOffset={0.5}
           outlineColor="accent.emphasis"
           overflow="hidden"
-          _hover={{
-            translateX: "100px",
-          }}
         >
           {imgSrc ? (
             <Image

--- a/src/components/features/HomePage/TechStack/TechStack.tsx
+++ b/src/components/features/HomePage/TechStack/TechStack.tsx
@@ -59,7 +59,7 @@ export const TechStack = ({ ...restProps }) => {
         className="group"
         maskImage="linear-gradient(to right, transparent, white 15%, white 90%, transparent)"
         color="fg.default"
-        _motionSafe={{ overflowX: "hidden" }}
+        overflowX="hidden"
         _motionReduce={{ overflowX: "scroll", px: "20" }}
         pb="10"
       >

--- a/src/components/shared/PageContainer/PageContainer.tsx
+++ b/src/components/shared/PageContainer/PageContainer.tsx
@@ -1,5 +1,11 @@
 import { Container, ContainerProps } from "@/styled-system/jsx";
 
 export const PageContainer = ({ ...restProps }: ContainerProps) => {
-  return <Container maxWidth={{ base: "5xl" }} {...restProps} />;
+  return (
+    <Container
+      maxWidth={{ base: "5xl" }}
+      mx={{ base: "unset", lg: "auto" }}
+      {...restProps}
+    />
+  );
 };


### PR DESCRIPTION
## Description

Fixes three sources of mobile layout breakage:

- **PageContainer**: `mx="auto"` was centering the container on all breakpoints, causing content misalignment on mobile. Changed to `mx={{ base: "unset", lg: "auto" }}` so auto-centering only kicks in at `lg+`.
- **TechStack**: `overflowX: "hidden"` was scoped inside `_motionSafe` (a `prefers-reduced-motion` media query), meaning it was conditionally applied rather than always. Moved it to always apply so the wide marquee content is consistently clipped.
- **Member avatar**: Removed a stray `translateX: "100px"` in the hover state was shifting the avatar 100px to the right on tap (mobile touch triggers hover), creating horizontal scroll.

## Jira Ticket

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🛠️ Refactor / Code improvement
- [ ] 🚀 Performance optimization
- [ ] ✅ Test enhancement

## Checklist

- [x] I have tested my changes and verified expected behavior.
- [x] I have performed a self-review of my code.
- [x] I have ensured this PR adheres to coding standards and best practices.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added necessary tests or ensured existing tests pass.
