### PR TITLE
Chore: Dependabot Setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,6 +90,28 @@ updates:
           - "minor"
           - "patch"
 
+      # Linting & Formatting
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint*"
+          - "typescript-eslint"
+          - "prettier"
+        update-types:
+          - "minor"
+          - "patch"
+
+      # Commit & Git Hooks
+      commitlint:
+        patterns:
+          - "@commitlint/*"
+          - "husky"
+          - "lint-staged"
+        update-types:
+          - "minor"
+          - "patch"
+
     # Ignore major version updates (require manual review)
     ignore:
       - dependency-name: "react"
@@ -106,3 +128,13 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      time: "06:00"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,108 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      time: "06:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "pnpm"
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    allow:
+      - dependency-type: "direct"
+    rebase-strategy: "auto"
+
+    groups:
+      # Core Framework
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+        update-types:
+          - "minor"
+          - "patch"
+
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+      typescript:
+        patterns:
+          - "typescript"
+        update-types:
+          - "minor"
+          - "patch"
+
+      # UI & Styling
+      ark-ui:
+        patterns:
+          - "@ark-ui/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+      radix-ui:
+        patterns:
+          - "@radix-ui/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+      panda-css:
+        patterns:
+          - "@pandacss/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+      lucide:
+        patterns:
+          - "lucide-react"
+          - "react-icons"
+        update-types:
+          - "minor"
+          - "patch"
+
+      # Build Tools
+      vite:
+        patterns:
+          - "@vitejs/*"
+          - "vite"
+          - "vite-*"
+        update-types:
+          - "minor"
+          - "patch"
+
+      # Type Definitions
+      types:
+        patterns:
+          - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+    # Ignore major version updates (require manual review)
+    ignore:
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@tanstack/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@ark-ui/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@pandacss/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ Add a link or reference to the Jira ticket associated with this PR (e.g., ES-1).
 - [ ] ✅ `test:` Adding or updating tests
 - [ ] 🔧 `chore:` Maintenance tasks (dependencies, configs, etc)
 - [ ] 🔄 `ci:` CI/CD changes
+- [ ] ↩️ `revert:` Revert a previous commit
 
 ## Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,13 +8,17 @@ Add a link or reference to the Jira ticket associated with this PR (e.g., ES-1).
 
 ## Type of Change
 
-- [ ] 🐛 Bug fix
-- [ ] ✨ New feature
-- [ ] 🔥 Breaking change
-- [ ] 📚 Documentation update
-- [ ] 🛠️ Refactor / Code improvement
-- [ ] 🚀 Performance optimization
-- [ ] ✅ Test enhancement
+- [ ] 🐛 `fix:` Bug fix (non-breaking change which fixes an issue)
+- [ ] ✨ `feat:` New feature (non-breaking change which adds functionality)
+- [ ] 🔥 `feat!:` or `fix!:` Breaking change (fix or feature that would cause
+      existing functionality to not work as expected)
+- [ ] 📚 `docs:` Documentation update
+- [ ] 🛠️ `refactor:` Code refactoring (no functional changes)
+- [ ] 🎨 `style:` Code style changes (formatting, missing semi-colons, etc)
+- [ ] 🚀 `perf:` Performance improvement
+- [ ] ✅ `test:` Adding or updating tests
+- [ ] 🔧 `chore:` Maintenance tasks (dependencies, configs, etc)
+- [ ] 🔄 `ci:` CI/CD changes
 
 ## Checklist
 

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,0 +1,42 @@
+name: Dependabot Merge
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --auto \
+            --squash \
+            --delete-branch \
+            --repo ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Flag major updates for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --add-label "needs manual review" \
+            --repo ${{ github.repository }}
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "⚠️ This PR contains a **major version update** and requires manual review before merging." \
+            --repo ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Sets up Dependabot for automated dependency management, tailored to the project's stack (TanStack Start + Vite), with an auto-merge workflow for safe, low-noise updates.

**`dependabot.yml`**
- `npm` ecosystem with package groups to reduce PR noise: `react`, `tanstack`, `typescript`, `ark-ui`, `radix-ui`, `panda-css`, `lucide`, `vite`, `types`, `eslint`, `commitlint`
- 7-day cooldown on all updates (14 days for major) to reduce supply-chain attack exposure
- Major version bumps blocked from auto-merge — require manual review
- `github-actions` ecosystem added to keep workflow action SHAs up to date via Dependabot
- Target branch: `develop`

**`dependabot-merge.yml`**
- Triggers on `pull_request_target` (ensures write-capable token for Dependabot PRs)
- Auto-merges patch and minor updates via squash, deletes branch after merge
- Flags major updates with `needs manual review` label and a PR comment
- `fetch-metadata` action pinned to commit SHA for supply-chain safety

## Jira Ticket

N/A

## Type of Change

- [ ] 🐛 `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feat:` New feature (non-breaking change which adds functionality)
- [ ] 🔥 `feat!:` or `fix!:` Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 `docs:` Documentation update
- [ ] 🛠️ `refactor:` Code refactoring (no functional changes)
- [ ] 🎨 `style:` Code style changes (formatting, missing semi-colons, etc)
- [ ] 🚀 `perf:` Performance improvement
- [ ] ✅ `test:` Adding or updating tests
- [x] 🔧 `chore:` Maintenance tasks (dependencies, configs, etc)
- [x] 🔄 `ci:` CI/CD changes
- [ ] ↩️ `revert:` Revert a previous commit

## Checklist

- [x] I have tested my changes and verified expected behavior.
- [x] I have performed a self-review of my code.
- [x] I have ensured this PR adheres to coding standards and best practices.
- [x] I have updated the documentation (if applicable).
- [ ] I have added necessary tests or ensured existing tests pass.
