### PR TITLE
Chore: Claude Code workflow rules and skills (SW-30)

### DIFF
--- a/.claude/commands/jira.md
+++ b/.claude/commands/jira.md
@@ -1,0 +1,45 @@
+# Pull Jira Ticket
+
+Fetch and display the Jira ticket: $ARGUMENTS
+
+## Steps
+
+1. Use the env vars `$JIRA_EMAIL`, `$JIRA_API_TOKEN`, and `$JIRA_BASE_URL` (all set in the shell).
+2. Run:
+
+```bash
+curl -s -u "$JIRA_EMAIL:$JIRA_API_TOKEN" \
+  "${JIRA_BASE_URL}rest/api/3/issue/$ARGUMENTS" \
+  | python3 -c "
+import json, sys
+
+def extract_text(node):
+    if not node:
+        return ''
+    if isinstance(node, str):
+        return node
+    if node.get('type') == 'text':
+        return node.get('text', '')
+    result = ''
+    for child in node.get('content', []):
+        result += extract_text(child)
+    if node.get('type') in ('paragraph', 'heading', 'listItem', 'bulletList', 'orderedList'):
+        result += '\n'
+    return result
+
+d = json.load(sys.stdin)
+f = d['fields']
+print('Summary:', f['summary'])
+print('Status:', f['status']['name'])
+print('Type:', f['issuetype']['name'])
+print('Assignee:', (f.get('assignee') or {}).get('displayName', 'Unassigned'))
+print()
+desc = f.get('description')
+if desc:
+    print('Description:')
+    print(extract_text(desc))
+"
+```
+
+3. Present the output clearly — summary, status, assignee, then the full description. If the ticket has acceptance criteria, call them out explicitly.
+4. After displaying, ask: "Ready to start on this?" unless the user has already indicated they want to proceed.

--- a/.claude/commands/new-section.md
+++ b/.claude/commands/new-section.md
@@ -2,46 +2,85 @@
 
 Create a new homepage section named: $ARGUMENTS
 
-## Rules
+## Steps
 
-Read CLAUDE.md before starting. Follow these conventions exactly.
+### 1. Read context first (always, before writing any code)
 
-### File structure
+- Read `~/Workspace/syncity-assistant/resources/syncity-web/implementation-status.md` — confirm this section is next and check for relevant key decisions.
+- Read the section spec in `~/Workspace/syncity-assistant/resources/syncity-web/handoff/06-sections.md` — find the matching section heading.
+- Read `~/Workspace/syncity-assistant/resources/syncity-web/handoff/design-reference/syncity-app-v3.jsx` — extract the exact copy, SVG glyphs, and JSX structure for this section.
+- Check what atoms are available in `src/components/core/` — do not create atoms the ticket says already exist.
+
+### 2. Implement
 
 Create `src/components/features/HomePage/$ARGUMENTS/` with:
 - `$ARGUMENTS.tsx` — the main section component
-- Sub-components in the same directory if the section has repeated items (e.g., `$ARGUMENTSCard.tsx`, `$ARGUMENTSItem.tsx`)
+- Sub-components in the same directory if the section has repeated items (e.g., `$ARGUMENTSCard.tsx`)
 
-### Section conventions
+#### Section conventions
 
 - Root element: `<Section>` from `@/components/core/Section/Section`
-- Consistent section padding: check existing sections for the rhythm (`py="16"` is common)
-- Section title: `<Heading as="h2">` — never skip the h2, it's required for accessibility and SEO heading hierarchy
-- If the section has a short eyebrow label above the heading, use a `<Text>` with appropriate styling (or a dedicated `SectionLabel` atom if one exists)
-- Data: static data arrays belong in `src/constants/` not inline in the component
+- Section padding: `py={{ base: '16', md: '20' }}` unless the spec says otherwise
+- Section header pattern: 2-col grid on `md`+ (Eyebrow + h2 left, intro paragraph right), collapses to 1 on mobile
+- `<Eyebrow>` for the label above the heading, `<Heading as="h2">` for the section title
+- Italic accent phrase in headings: use `<em className={css({ fontFamily: 'heading', fontStyle: 'italic', fontWeight: 'inherit', color: 'accent.default' })}>`
+- Hairline grid layout (borders between cells, not gaps): implement directly with `styled('div')` + `borderTop` on container, `borderRight` between cells on desktop, `borderBottom` between cells on mobile — the `<HairlineGrid>` atom in core is the Hero background grid, not a layout primitive
+- Static data: put arrays in `src/constants/` if they'll be reused; keep inline for one-off section data
 
-### Token rules (enforced — no exceptions)
+#### Token rules (no exceptions)
 
-- Colors → semantic tokens only (`accent.default`, `fg.muted`, `bg.subtle`, etc.)
+- Colors → semantic tokens (`accent.default`, `fg.muted`, `bg.subtle`, etc.) or `colorPalette.*`
 - Never hardcode hex values, raw px shadows, raw font families
-- Surfaces → `layerStyle` prop for any card/panel elements
+- Surfaces → `layerStyle` prop (`surfaceRaised`, `surfaceElevated`, etc.)
 - Responsive → always define `base` + at least `md` breakpoint values
+- SVG attributes can't use Panda token refs — use `var(--colors-*)` CSS variables directly
 
-### Accessibility
+#### Button / interactive elements (post SW-29)
 
-- `<Section>` renders a `<section>` — add `aria-labelledby` pointing to the section's `<h2>` id if the section isn't otherwise labeled
-- Decorative images: `alt=""` and `aria-hidden="true"`
-- Animated/scrolling elements: use `_motionSafe` for the animation and `_motionReduce` for a static fallback
+- Use `variant` not `visual` on `<Button>`
+- Variants: `solid / surface / subtle / outline / plain`
+- Use `<LinkButton>` for anchor buttons (not `<Button href="...">`)
+- `inverted` variant is gone — handle FinalCTA surface inversion via section-level styling
 
-### Wiring up
+#### Accessibility
 
-After creating the section files:
-1. Import the new section in `src/components/features/HomePage/Home.tsx`
-2. Add it in the correct position in the JSX
+- Add `id` to the `<Section>` matching the nav anchor (e.g., `id="work"`)
+- `aria-hidden="true"` on decorative SVGs and duplicates
+- `_motionReduce` fallback on any animated elements
+- Heading hierarchy: h2 for section title, h3 and below inside sections
+
+### 3. Wire up
+
+Import the section in `src/components/features/HomePage/Home.tsx` and add it in the correct position per the v3 page order:
+
+```
+Hero → Principles → Team → Process → Stack → Contact → FinalCTA → Footer
+```
+
+### 4. Type-check
+
+```bash
+npx tsc --noEmit 2>&1 | grep -v "style-context.tsx" | grep -v "is not assignable to type 'Props'"
+```
+
+Must be clean before committing.
+
+### 5. Commit and PR
+
+- Commit: `feat(section-name): implement <Section Name> section`
+- Open / update PR using the team template (Description · Jira Ticket · Type of Change · Checklist)
+- Jira ticket link: `https://syncity.atlassian.net/browse/<TICKET-ID>`
+
+### 6. Update implementation status
+
+Edit `~/Workspace/syncity-assistant/resources/syncity-web/implementation-status.md`:
+- Mark this section ✅ with the PR number
+- Mark the next section as "Next"
+- Bump the "Last updated" date
+- Add any new key decisions (API surprises, token workarounds, component gotchas)
 
 ### After creating
 
 Show:
 1. The file tree of what was created
 2. The updated `Home.tsx` showing where the section was inserted
-3. A note on any new core atoms that should be extracted if the section introduced a reusable pattern

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,3 +226,20 @@ When adding `og:image`, provide an absolute URL.
 - The app is SSR via Nitro. Avoid `window` / `document` access outside `useEffect` or after a `typeof window !== 'undefined'` guard.
 - `COLOR_MODE_INIT_SCRIPT` runs as an inline script before hydration to avoid color mode flash.
 - Images via `@unpic/react` handle responsive sizing and lazy loading — use `layout="constrained"` for fixed-size images, `layout="fullWidth"` for full-container images.
+
+---
+
+## v3 Redesign Workflow
+
+### Before implementing any `features/HomePage` section
+
+1. Read `~/Workspace/syncity-assistant/resources/syncity-web/implementation-status.md` — check what's done and what's next.
+2. Read the relevant section spec in `~/Workspace/syncity-assistant/resources/syncity-web/handoff/06-sections.md`.
+3. Open `~/Workspace/syncity-assistant/resources/syncity-web/handoff/design-reference/syncity-app-v3.jsx` to extract copy, SVGs, and structure for the target section.
+
+### After a section PR is created
+
+Update `~/Workspace/syncity-assistant/resources/syncity-web/implementation-status.md`:
+- Mark the completed section ✅ with its PR number.
+- Mark the next section as "Next".
+- Add any new key decisions that aren't already documented (API changes, gotchas, token workarounds).


### PR DESCRIPTION
## Description

Adds Claude Code workflow automation for the v3 redesign implementation cycle — reducing repeated prompts and missed steps between sessions.

**Changes:**
- `CLAUDE.md` — new **v3 Redesign Workflow** section with two standing rules:
  - Before any `features/HomePage` section: read `implementation-status.md` → `06-sections.md` → `syncity-app-v3.jsx` for context before writing code
  - After PR is created: update `implementation-status.md` (mark section ✅, advance "Next", add key decisions)
- `.claude/commands/jira.md` — new `/jira <TICKET-ID>` skill: fetches any Jira ticket via the `$JIRA_EMAIL` / `$JIRA_API_TOKEN` / `$JIRA_BASE_URL` env vars already set in the shell; formats summary, status, assignee, and full description
- `.claude/commands/new-section.md` — updated `/new-section` skill: full end-to-end checklist covering design reference lookup, token rules, post-SW-29 Button API, HairlineGrid gotcha, SVG CSS var workaround, wiring into `Home.tsx`, type-check, commit, PR, and implementation status update

## Jira Ticket

[SW-30](https://syncity.atlassian.net/browse/SW-30)

## Type of Change

- [ ] 🐛 `fix:` Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ `feat:` New feature (non-breaking change which adds functionality)
- [ ] 🔥 `feat!:` or `fix!:` Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 `docs:` Documentation update
- [ ] 🛠️ `refactor:` Code refactoring (no functional changes)
- [ ] 🎨 `style:` Code style changes (formatting, missing semi-colons, etc)
- [ ] 🚀 `perf:` Performance improvement
- [ ] ✅ `test:` Adding or updating tests
- [x] 🔧 `chore:` Maintenance tasks (dependencies, configs, etc)
- [ ] 🔄 `ci:` CI/CD changes
- [ ] ↩️ `revert:` Revert a previous commit

## Checklist

- [x] I have tested my changes and verified expected behavior.
- [x] I have performed a self-review of my code.
- [x] I have ensured this PR adheres to coding standards and best practices.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added necessary tests or ensured existing tests pass.