### PR TITLE
Feature: Implement final cta inverted section (SW-21)

### DIFF
--- a/src/components/features/HomePage/FinalCTA/FinalCTA.tsx
+++ b/src/components/features/HomePage/FinalCTA/FinalCTA.tsx
@@ -1,0 +1,77 @@
+import { Mail } from 'lucide-react';
+
+import { DisplayItalic } from '@/components/core/DisplayItalic/DisplayItalic';
+import { Eyebrow } from '@/components/core/Eyebrow/Eyebrow';
+import { Heading } from '@/components/core/Heading/Heading';
+import { LinkButton } from '@/components/core/LinkButton/LinkButton';
+import { Section } from '@/components/core/Section/Section';
+import { Text } from '@/components/core/Text/Text';
+import { styled } from '@/styled-system/jsx';
+
+const Card = styled('div', {
+  base: {
+    bg: 'fg.default',
+    color: 'bg.default',
+    rounded: 'l4',
+    px: { base: '7', md: '12' },
+    py: { base: '9', md: '14' },
+    display: 'grid',
+    gridTemplateColumns: { base: '1fr', md: '1.5fr 1fr' },
+    gap: { base: '8', md: '12' },
+    alignItems: 'center',
+    position: 'relative',
+    overflow: 'hidden',
+    _dark: {
+      bg: 'bg.muted',
+      color: 'fg.default',
+    },
+  },
+});
+
+const RightCol = styled('div', {
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '3.5',
+    alignItems: 'flex-start',
+  },
+});
+
+export const FinalCTA = () => (
+  <Section id="cta" pt={{ base: '16', md: '20' }} pb="0">
+    <Card>
+      <div>
+        <Heading as="h3" textStyle={{ base: '5xl', md: '6xl' }} lineHeight="1" color="inherit">
+          Got something you'd like
+          <br />
+          to <DisplayItalic>build well?</DisplayItalic>
+        </Heading>
+        <Text size="md" mt="4" maxW="50ch" lineHeight="1.5" opacity="0.6">
+          One short email is all it takes. We read every one and reply personally — even if it's not
+          the right fit.
+        </Text>
+      </div>
+
+      <RightCol>
+        <LinkButton
+          href="mailto:team@syncity.dev"
+          variant="solid"
+          size="md"
+          bg="bg.default"
+          color="fg.default"
+          _hover={{ bg: 'bg.muted' }}
+          _dark={{
+            bg: 'fg.default',
+            color: 'bg.default',
+            _hover: { bg: 'fg.muted' },
+          }}
+        >
+          team@syncity.dev <Mail />
+        </LinkButton>
+        <Eyebrow color="currentColor" opacity="0.75">
+          No forms required · No funnels
+        </Eyebrow>
+      </RightCol>
+    </Card>
+  </Section>
+);

--- a/src/components/features/HomePage/Home.tsx
+++ b/src/components/features/HomePage/Home.tsx
@@ -1,4 +1,5 @@
 import { ContactUs } from '@/components/features/HomePage/ContactUs/ContactUs';
+import { FinalCTA } from '@/components/features/HomePage/FinalCTA/FinalCTA';
 import { Hero } from '@/components/features/HomePage/Hero/Hero';
 import { Principles } from '@/components/features/HomePage/Principles/Principles';
 import { Process } from '@/components/features/HomePage/Process/Process';
@@ -14,5 +15,6 @@ export const Home = () => (
     <Process />
     <TechStack />
     <ContactUs />
+    <FinalCTA />
   </PageContainer>
 );

--- a/src/components/features/HomePage/Team/Team.tsx
+++ b/src/components/features/HomePage/Team/Team.tsx
@@ -10,7 +10,7 @@ import { Grid } from '@/styled-system/jsx';
 export const Team = () => (
   <Section id="team" py={{ base: '16', md: '20' }}>
     <SectionHeader eyebrow="THE TEAM">
-      <Heading as="h2">
+      <Heading as="h2" textStyle="sectionTitle">
         Three of us. <DisplayItalic>That&rsquo;s it.</DisplayItalic>
       </Heading>
       <Text size="lg" color="fg.muted">

--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -17,6 +17,7 @@ export const Footer = () => {
       borderTopWidth="1px"
       borderTopStyle="solid"
       borderTopColor="border.default"
+      mt="8"
     >
       <Box maxWidth="7xl" mx="auto" px={{ base: '4', md: '7' }}>
         <Grid


### PR DESCRIPTION
## Description

Implements the v3 FinalCTA section (SW-21) — an inverted 2-column card placed after the Contact section as the last call-to-action before the footer.

**FinalCTA (`features/HomePage/FinalCTA/FinalCTA.tsx`)** — new section
- Dark inverted card: `bg: fg.default` / `color: bg.default` in light mode; flips to `bg: bg.muted` / `color: fg.default` in dark mode
- 2-column grid (`1.5fr 1fr`, gap 12) collapsing to 1 column below `md`
- Left col: `<Heading as="h3">` with `<DisplayItalic>` accent on "build well?" + body `<Text opacity="0.6">`
- Right col: `<LinkButton>` styled as a light-on-dark button using semantic token overrides (`bg.default` base, `fg.default` in `_dark`); hover uses `bg.muted` for visible contrast on the near-white surface; `<Eyebrow color="currentColor" opacity="0.75">` beneath

**Home.tsx** — `<FinalCTA />` wired in after `<ContactUs />`

**Incidental fixes on this branch:**
- `fix(team)`: apply `textStyle="sectionTitle"` to Team h2 (was missing, left default `3xl`)
- `fix(footer)`: add `mt="8"` to Footer to separate it from the FinalCTA card

## Jira Ticket

[SW-21](https://syncity.atlassian.net/browse/SW-21)

## Type of Change

- [ ] 🐛 `fix:` Bug fix (non-breaking change which fixes an issue)
- [x] ✨ `feat:` New feature (non-breaking change which adds functionality)
- [ ] 🔥 `feat!:` or `fix!:` Breaking change (fix or feature that would cause
      existing functionality to not work as expected)
- [ ] 📚 `docs:` Documentation update
- [ ] 🛠️ `refactor:` Code refactoring (no functional changes)
- [ ] 🎨 `style:` Code style changes (formatting, missing semi-colons, etc)
- [ ] 🚀 `perf:` Performance improvement
- [ ] ✅ `test:` Adding or updating tests
- [ ] 🔧 `chore:` Maintenance tasks (dependencies, configs, etc)
- [ ] 🔄 `ci:` CI/CD changes
- [ ] ↩️ `revert:` Revert a previous commit

## Checklist

- [x] I have tested my changes and verified expected behavior.
- [x] I have performed a self-review of my code.
- [x] I have ensured this PR adheres to coding standards and best practices.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added necessary tests or ensured existing tests pass.
