### PR TITLE
Fix: Add Entrance Animations to IsoDeco and HomePage Section Reveals (SW-35)

### DIFF
--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -15,7 +15,7 @@ export const useInView = <T extends Element>(options?: IntersectionObserverInit)
           observer.disconnect();
         }
       },
-      { threshold: 0.4, ...options },
+      { threshold: 0, rootMargin: '0px 0px -15% 0px', ...options },
     );
 
     observer.observe(el);


### PR DESCRIPTION
## Description

Fixes scroll-triggered section reveals not firing on mobile (iPhone 15 Pro, Safari) for sections below Principles.

Root cause: `threshold: 0.4` requires 40% of the element to be simultaneously visible before the `IntersectionObserver` fires. On mobile, tall sections (Team, Process, Stack, Contact, FinalCTA) exceed the viewport height, so 40% is never visible at once — the callback never fires and the sections stay permanently hidden (`visibility: hidden`).

Fix: replace `threshold` with `rootMargin: '0px 0px -15% 0px'` at `threshold: 0`. This fires as soon as the section's top edge is 15% up from the bottom of the viewport, regardless of section height.

## Jira Ticket

[SW-35](https://syncity.atlassian.net/browse/SW-35)

## Type of Change

- [x] 🐛 `fix:` Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested my changes and verified expected behavior.
- [x] I have performed a self-review of my code.
- [x] I have ensured this PR adheres to coding standards and best practices.
- [x] I have updated the documentation (if applicable).
- [x] I have added necessary tests or ensured existing tests pass.
